### PR TITLE
Enforce stricter integer parsing on encode function

### DIFF
--- a/hashids.js
+++ b/hashids.js
@@ -12,6 +12,14 @@ export default class Hashids {
 
 		let uniqueAlphabet = '', sepsLength, diff;
 
+		this.filterInt = (value) => {
+			if(/^(\-|\+)?([0-9]+|Infinity)$/.test(value)) {
+				return parseInt(value, 10);
+			}
+
+			return NaN;
+		}
+
 		/* alphabet vars */
 
 		this.escapeRegExp = (s) => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
@@ -104,7 +112,7 @@ export default class Hashids {
 		}
 
 		for (let i = 0; i !== numbers.length; i++) {
-			numbers[i] = parseInt(numbers[i], 10);
+			numbers[i] = this.filterInt(numbers[i]);
 			if (numbers[i] >= 0) {
 				continue;
 			} else {

--- a/tests/bad-input.js
+++ b/tests/bad-input.js
@@ -33,6 +33,11 @@ describe('bad input', () => {
 		assert.equal(id, '');
 	});
 
+	it(`should return an empty string when encoding a string with non-numeric characters`, () => {
+		const id = hashids.encode('6B');
+		assert.equal(id, '');
+	});
+
 	it(`should return an empty string when encoding a null`, () => {
 		const id = hashids.encode(null);
 		assert.equal(id, '');


### PR DESCRIPTION
Currently, the `encode` function in hashids is using `parseInt` in order to validate that a stringified number is indeed a number before encoding. However, there is a caveat to parseInt, [detailed in MDN's documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#Description):
> If `parseInt` encounters a character that is not a numeral in the specified radix, it ignores it and all succeeding characters and returns the integer value parsed up to that point.

If an API consumer were to pass `hashids.encode('B6')`, this would result in a proper result of `''` since the API specifies returning an empty string if an integer is not received.

However, if the consumer were to pass `hashids.encode('6B')`, the `parseInt` function would parse this as `6` and ignore the succeeding characters. This would allow the encode function to continue with the encode, even though the function was passed a bad value.

I've updated the tests to demonstrate the issue. To address the bug, I added a stricter `filterInt` function. This function verifies that the number being passed is indeed an integer before executing `parseInt`. I pulled `filterInt` from [MDN's documentation on parseInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#A_stricter_parse_function)  and modified it to be a bit cleaner.

Thanks to @juliancoleman for pairing with me to find/implement a fix for this bug.