### PR TITLE
improved _shuffle performance

### DIFF
--- a/lib/hashids.js
+++ b/lib/hashids.js
@@ -277,17 +277,21 @@ export default class Hashids {
 			return alphabet;
 		}
 
+		alphabet = alphabet.split("");
+
 		for (let i = alphabet.length - 1, v = 0, p = 0, j = 0; i > 0; i--, v++) {
 
 			v %= salt.length;
-			p += integer = salt.charAt(v).charCodeAt(0);
+			p += integer = salt.charCodeAt(v);
 			j = (integer + v + p) % i;
 
 			const tmp = alphabet[j];
-			alphabet = alphabet.substr(0, j) + alphabet.charAt(i) + alphabet.substr(j + 1);
-			alphabet = alphabet.substr(0, i) + tmp + alphabet.substr(i + 1);
+			alphabet[j] = alphabet[i];
+			alphabet[i] = tmp;
 
 		}
+
+		alphabet = alphabet.join("");
 
 		return alphabet;
 


### PR DESCRIPTION
It's 45% faster in Chrome 55, 33% in Firefox 50 - see https://jsperf.com/test-changes