### PR TITLE
display default alphabet in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ var hashids = new Hashids('', 0, 'abcdefghijklmnopqrstuvwxyz'); // all lowercase
 console.log(hashids.encode(1, 2, 3)); // mdfphx
 ```
 
+Default alphabet is `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`.
+
 **Encode hex instead of numbers:**
 
 Useful if you want to encode [Mongo](https://www.mongodb.com/)'s ObjectIds. Note that *there is no limit* on how large of a hex number you can pass (it does not have to be Mongo's ObjectId).


### PR DESCRIPTION
Some other libraries ([shortid](https://github.com/dylang/shortid) for example) include dashes and/or underscores in their default alphabet, which may not be desired. It's nice to see the default set listed if this aspect is important for the developer.